### PR TITLE
fix(docs): empty space was causing page title and header to be malformed

### DIFF
--- a/docs/docs/configuration/networking-settings.mdx
+++ b/docs/docs/configuration/networking-settings.mdx
@@ -1,4 +1,3 @@
-
 ---
 title: Network and Security Settings
 sidebar_position: 7


### PR DESCRIPTION
### SUMMARY
What it says in the title :)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**BEFORE**
![image](https://github.com/user-attachments/assets/7fd4fc70-d9cb-439b-bbf1-9e6908499bd4)

**AFTER**
![image](https://github.com/user-attachments/assets/af28950e-3bdb-41ba-9f8d-0e17cb890465)
