### PR TITLE
fix(docs): fix quickstart guide

### DIFF
--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -31,6 +31,9 @@ $ git clone https://github.com/apache/superset
 # Enter the repository you just cloned
 $ cd superset
 
+# Set the repo to the state associated with the latest official version
+$ git checkout tags/4.1.1
+
 # Fire up Superset using Docker Compose
 $ docker compose -f docker-compose-image-tag.yml up
 ```


### PR DESCRIPTION
### SUMMARY
A short-term fix for #31510. The install process of `docker-compose-image-tag.yml` is broken because the master branch files like `[docker/docker-bootstrap.sh](https://github.com/apache/superset/blob/master/docker/docker-bootstrap.sh)` now use `uv` but that package is missing in official versions like `4.1.1`.

Hard-coding a version here is not ideal but this gets new users going again. After the next official release cut from the main/master branch, if `docker compose -f docker-compose-image-tag.yml up` again works without specifying a certain tag, we can revert this PR.

### TESTING INSTRUCTIONS
Test the steps in the quickstart and see that it works now.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #31510